### PR TITLE
Add x-checker-data for automatic update PRs

### DIFF
--- a/org.azahar_emu.Azahar.json
+++ b/org.azahar_emu.Azahar.json
@@ -50,19 +50,37 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/KhronosGroup/glslang/archive/refs/tags/15.1.0.zip",
-                    "sha256": "c4cc5083dd198640f3ad9d2014ac9b31433495a57cd3fb2420cd4e8ea8eb4b2b"
+                    "sha256": "c4cc5083dd198640f3ad9d2014ac9b31433495a57cd3fb2420cd4e8ea8eb4b2b",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "stable-only": true,
+                        "project-id": 205796,
+                        "url-template": "https://github.com/KhronosGroup/glslang/archive/refs/tags/$version.zip"
+                    }
                 },
                 {
                     "type": "archive",
                     "url": "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.4.304.1.tar.gz",
                     "sha256": "9fe736980d424c04f1303ae71b94b18bcc6046ae348909c393344a45e1bd7ff8",
-                    "dest": "External/spirv-tools"
+                    "dest": "External/spirv-tools",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "stable-only": true,
+                        "project-id": 334920,
+                        "url-template": "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-$version.tar.gz"
+                    }
                 },
                 {
                     "type": "archive",
                     "url": "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.304.1.tar.gz",
                     "sha256": "66e6cec19e7433fc58ace8cdf4040be0d52bb5920e54109967df2dd9598a8d48",
-                    "dest": "External/spirv-tools/external/spirv-headers"
+                    "dest": "External/spirv-tools/external/spirv-headers",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "stable-only": true,
+                        "project-id": 334920,
+                        "url-template": "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-$version.tar.gz"
+                    }
                 }
             ]
         },
@@ -81,7 +99,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz",
-                    "sha256": "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
+                    "sha256": "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "stable-only": true,
+                        "project-id": 7422,
+                        "url-template": "https://github.com/Tencent/rapidjson/archive/v$version.tar.gz"
+                    }
                 },
                 {
                     "type": "patch",
@@ -129,7 +153,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/azahar-emu/azahar/releases/download/2120.3/azahar-unified-source-20250414-00e3bbb.tar.xz",
-                    "sha256": "3e6c35bde6fc78021e6411e42a24aad7a889f5c556947925441bedc3e9aa242d"
+                    "sha256": "3e6c35bde6fc78021e6411e42a24aad7a889f5c556947925441bedc3e9aa242d",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/azahar-emu/azahar/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".assets[] | select(.name | test(\"^azahar-unified-source.*.xz$\")).browser_download_url"
+                    }
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
This will cause Flathub's infrastructure to run an hourly check on each of the module sources tagged here and create PRs to apply any updates where available. This means that once a new release gets tagged on eg. the glslang repo, or Azahar itself, there will be an automatic update and CI run for the Flatpak build. If the CI run completes successfully, Flathub's bot will post a command line for installing the test build to the PR; once someone has verified that this test build is okay they can then merge the PR to roll the update out to Flathub.