### PR TITLE
Retrigger build (attempt #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Azahar Flatpak Manfiest
 
 This repository contains the manifest files required to build Azahar on the Flatpak platform
+


### PR DESCRIPTION
Azahar 2121.1 seems to have failed to publish after being merged. This empty commit should re-trigger the build and hopefully publish the update correctly.

A minor change was made to README.md to achieve this, as empty commits seem to disappear when attempting to merge them via rebase.