### PR TITLE
Add x-checker for Azahar

### DIFF
--- a/org.azahar_emu.Azahar.json
+++ b/org.azahar_emu.Azahar.json
@@ -130,7 +130,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/azahar-emu/azahar/releases/download/2121.2/azahar-unified-source-2121.2.tar.xz",
-                    "sha256": "d22386172c8c59f3d9fa44d5da577f6b6c5ee0cb393cea3b4dece98c06ca3447"
+                    "sha256": "d22386172c8c59f3d9fa44d5da577f6b6c5ee0cb393cea3b4dece98c06ca3447",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/azahar-emu/azahar/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".assets[] | select(.name | test(\"^azahar-unified-source.*.xz$\")).browser_download_url"
+                    }
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
* When an update is pushed to the upstream Azahar repo, a PR is automatically opened on the Flathub repo and will have CI run a Flatpak build. If this builds successfully, a comment is created with a command to install and test the newest Flatpak. After review and testing, the PR can be merged and the update will be deployed to Flathub.

This is a follow-up PR to https://github.com/flathub/org.azahar_emu.Azahar/pull/2 but this only adds an x-checker module for Azahar itself. Dependencies can continue be updated manually as needed.

PPSSPP PR using x-checker for reference: 

![image](https://github.com/user-attachments/assets/a5b968f9-3659-4bfd-9cf3-ce28a8b515bf)
