### PR TITLE
Updated Azahar to 2123.4.1

### DIFF
--- a/org.azahar_emu.Azahar.json
+++ b/org.azahar_emu.Azahar.json
@@ -15,8 +15,7 @@
     },
     "finish-args": [
         "--device=all",
-        "--socket=wayland",
-        "--socket=fallback-x11",
+        "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
         "--share=ipc",
@@ -103,8 +102,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/azahar-emu/azahar/releases/download/2123.2/azahar-unified-source-2123.2.tar.xz",
-                    "sha256": "d77ff77392f9f78bfd3543b8cbb8c3a83a6008bf73bf6dd748c4264edb5f82d1"
+                    "url": "https://github.com/azahar-emu/azahar/releases/download/2123.4.1/azahar-unified-source-2123.4.1.tar.xz",
+                    "sha256": "09d4d0478d81860acc312be92896ce4d9d84e7deb870ba069ee393c1d88dac0e"
                 },
                 {
                     "type": "file",

--- a/org.azahar_emu.Azahar.metainfo.xml
+++ b/org.azahar_emu.Azahar.metainfo.xml
@@ -30,6 +30,13 @@
   </screenshots>
   <releases>
 
+    <release version="2123.4.1" date="2026-01-09">
+      <description>
+        <p>Read the changelog here:</p>
+        <p>https://github.com/azahar-emu/azahar/releases/tag/2123.4.1</p>
+      </description>
+    </release>
+    
     <release version="2123.2" date="2025-09-16">
       <description>
         <p>Read the changelog here:</p>


### PR DESCRIPTION
Native Wayland support has been disabled by default for reasons described in the 2123.4 changelog.