### PR TITLE
azahar-launcher.sh: Fixed incorrect ulimit command

### DIFF
--- a/azahar-launcher.sh
+++ b/azahar-launcher.sh
@@ -11,7 +11,7 @@ You seem to be using ${XDG_SESSION_DESKTOP} ${DESKTOP_SESSION} (${XDG_SESSION_TY
 To obtain Azahar log files, please see <a href="https://web.archive.org/web/20240229211203/https://community.citra-emu.org/t/how-to-upload-the-log-file/296/">this guide</a>.
 
 To obtain your system information, please install <tt>inxi</tt> and run <tt>inxi -v3</tt>.
-Please also provide the value shown after running <tt>ulimit -nH</tt>. |
+Please also provide the value shown after running <tt>ulimit -n -H</tt>. |
 EOF
     zenity --warning --no-wrap --title "That's awkward ..." --text "$MESSAGE"
 }


### PR DESCRIPTION
The previously displayed ulimit command seemingly only works on zsh, not bash.