### PR TITLE
WIP: Testing whether ENABLE_OPENGL=ON would break raspberry pi 5 

### DIFF
--- a/org.azahar_emu.Azahar.json
+++ b/org.azahar_emu.Azahar.json
@@ -87,6 +87,7 @@
                 "-DCMAKE_CXX_COMPILER=clang++",
                 "-DCMAKE_LINKER=lld",
                 "-DENABLE_QT_TRANSLATION=ON",
+                "-DENABLE_OPENGL=ON",
                 "-DUSE_DISCORD_PRESENCE=ON",
                 "-DUSE_SYSTEM_SDL2=ON"
             ],


### PR DESCRIPTION
I see that the option was enabled here:
https://github.com/azahar-emu/azahar/pull/749

But this is not set in the flatpak build, I have a raspberry pi 5 for testing, so I figured I'd do a test build an see how it behaves. 