### PR TITLE
update azahar to 2125.1.2

### DIFF
--- a/org.azahar_emu.Azahar.json
+++ b/org.azahar_emu.Azahar.json
@@ -102,8 +102,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/azahar-emu/azahar/releases/download/2125.1.1/azahar-unified-source-2125.1.1.tar.xz",
-                    "sha256": "a1379f408a8d23825dd8adcd51a621a74719bd25c1a85db58ef2b61e96fba298"
+                    "url": "https://github.com/azahar-emu/azahar/releases/download/2125.1.2/azahar-unified-source-2125.1.2.tar.xz",
+                    "sha256": "688db108137fa6f4c29b48b187325a622afef7e3147e5f0b83c6996d96f7328f"
                 },
                 {
                     "type": "file",

--- a/org.azahar_emu.Azahar.metainfo.xml
+++ b/org.azahar_emu.Azahar.metainfo.xml
@@ -31,6 +31,10 @@
   </screenshots>
   <releases>
 
+    <release version="2125.1.2" date="2026-05-14">
+      <url>https://github.com/azahar-emu/azahar/releases/tag/2125.1.2</url>
+    </release>
+
     <release version="2125.1.1" date="2026-04-21">
       <url>https://github.com/azahar-emu/azahar/releases/tag/2125.1.1</url>
     </release>


### PR DESCRIPTION
I noticed this was skipped, as flathub is still on 2125.1.2. I know this release does not add any changes outside of technical changes to how azahar is being distributed, but I still think azahar on flathub should be up to date.

If this was intentionally skipped, sorry!

I followed how azahar was updated to 2125.1.1 in 8a8bc53f9f2dac9d10556d4d222896343ac5877b for this pr